### PR TITLE
Fix date pattern to parse the date correctly

### DIFF
--- a/java-sdk/src/test/java/com/guardtime/ksi/samples/ExtendingSamples.java
+++ b/java-sdk/src/test/java/com/guardtime/ksi/samples/ExtendingSamples.java
@@ -68,7 +68,7 @@ public class ExtendingSamples extends KsiSamples {
     public void printPublicationInfo() throws IOException, KSIException, ParseException {
         KSI ksi = getKsi();
 
-        Date publicationDate = new SimpleDateFormat("YYYY-MM-dd").parse("2016-02-01");
+        Date publicationDate = new SimpleDateFormat("yyyy-MM-dd").parse("2016-02-01");
         PublicationRecord publicationRecord = ksi.getPublicationsFile().getPublicationRecord(publicationDate);
 
         for (String s : publicationRecord.getPublicationReferences()) {


### PR DESCRIPTION
With YYYY "2016-02-01" ends up being parsed as "Sun Dec 27 00:00:00 EET 2015".
The correct pattern (as specified here https://docs.oracle.com/javase/8/docs/api/java/text/SimpleDateFormat.html) would be yyyy-MM-dd