### PR TITLE
Usage of the new separated interfaces

### DIFF
--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -5,7 +5,11 @@
 
 	<groupId>com.guardtime</groupId>
 	<artifactId>ksi-sdk-samples</artifactId>
-	<version>1.1</version>
+	<version>2.0</version>
+
+	<properties>
+		<ksi-java-sdk.version>4.10.114-SNAPSHOT</ksi-java-sdk.version>
+	</properties>
 
 	<dependencies>
 		<dependency>
@@ -16,17 +20,17 @@
 		<dependency>
 			<groupId>com.guardtime</groupId>
 			<artifactId>ksi-api</artifactId>
-			<version>4.5.72</version>
+			<version>${ksi-java-sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.guardtime</groupId>
 			<artifactId>ksi-service-client-simple-http</artifactId>
-			<version>4.5.72</version>
+			<version>${ksi-java-sdk.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>com.guardtime</groupId>
 			<artifactId>ksi-blocksigner</artifactId>
-			<version>4.5.72</version>
+			<version>${ksi-java-sdk.version}</version>
 		</dependency>
 	</dependencies>
 	<build>

--- a/java-sdk/pom.xml
+++ b/java-sdk/pom.xml
@@ -8,7 +8,7 @@
 	<version>2.0</version>
 
 	<properties>
-		<ksi-java-sdk.version>4.10.114-SNAPSHOT</ksi-java-sdk.version>
+		<ksi-java-sdk.version>4.10.117</ksi-java-sdk.version>
 	</properties>
 
 	<dependencies>

--- a/java-sdk/src/test/java/com/guardtime/ksi/samples/ExtendingSamples.java
+++ b/java-sdk/src/test/java/com/guardtime/ksi/samples/ExtendingSamples.java
@@ -14,20 +14,22 @@
  */
 package com.guardtime.ksi.samples;
 
-import java.io.IOException;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
+import com.guardtime.ksi.Extender;
 import com.guardtime.ksi.KSI;
+import com.guardtime.ksi.PublicationsHandler;
+import com.guardtime.ksi.Reader;
 import com.guardtime.ksi.exceptions.KSIException;
 import com.guardtime.ksi.publication.PublicationData;
 import com.guardtime.ksi.publication.PublicationRecord;
 import com.guardtime.ksi.unisignature.KSISignature;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 /**
  * Samples related to extending KSI signatures.
@@ -49,8 +51,9 @@ public class ExtendingSamples extends KsiSamples {
      */
     @Test
     public void checkExtended() throws IOException, KSIException {
-        KSI ksi = getKsi();
-        KSISignature signature = ksi.read(getFile("signme.txt.unextended-ksig"));
+        Reader reader = getReader();
+
+        KSISignature signature = reader.read(getFile("signme.txt.unextended-ksig"));
 
         if (signature.isExtended()) {
             System.out.println(
@@ -66,10 +69,10 @@ public class ExtendingSamples extends KsiSamples {
      */
     @Test
     public void printPublicationInfo() throws IOException, KSIException, ParseException {
-        KSI ksi = getKsi();
+        PublicationsHandler publicationsHandler = getPublicationsHandler();
 
         Date publicationDate = new SimpleDateFormat("yyyy-MM-dd").parse("2016-02-01");
-        PublicationRecord publicationRecord = ksi.getPublicationsFile().getPublicationRecord(publicationDate);
+        PublicationRecord publicationRecord = publicationsHandler.getPublicationsFile().getPublicationRecord(publicationDate);
 
         for (String s : publicationRecord.getPublicationReferences()) {
             System.out.println("printPublicationInfo > publication reference > " + s);
@@ -82,14 +85,17 @@ public class ExtendingSamples extends KsiSamples {
      */
     @Test
     public void reExtendToLatestPublication() throws IOException, KSIException {
-        KSI ksi = getKsi();
-        KSISignature signature = ksi.read(getFile("signme.txt.unextended-ksig"));
+        Reader reader = getReader();
+        Extender extender = getExtender();
+        PublicationsHandler publicationsHandler = getPublicationsHandler();
 
-        PublicationRecord latestPublicationRecord = ksi.getPublicationsFile().getLatestPublication();
+        KSISignature signature = reader.read(getFile("signme.txt.unextended-ksig"));
+
+        PublicationRecord latestPublicationRecord = publicationsHandler.getPublicationsFile().getLatestPublication();
         Date latestPublicationTime = latestPublicationRecord.getPublicationTime();
         if (!signature.isExtended()
                 || signature.getPublicationRecord().getPublicationTime().before(latestPublicationTime)) {
-            KSISignature extendedSignature = ksi.extend(signature, latestPublicationRecord);
+            KSISignature extendedSignature = extender.extend(signature, latestPublicationRecord);
 
             if (extendedSignature.isExtended()) {
                 System.out.println("reExtendToLatestPublication > signature extended to publication > "
@@ -106,16 +112,17 @@ public class ExtendingSamples extends KsiSamples {
      */
     @Test
     public void extendToClosestPublication() throws IOException, KSIException {
-        KSI ksi = getKsi();
+        Reader reader = getReader();
+        Extender extender = getExtender();
 
         // Read an existing signature from file, assume it to be not extended
-        KSISignature signature = ksi.read(getFile("signme.txt.unextended-ksig"));
+        KSISignature signature = reader.read(getFile("signme.txt.unextended-ksig"));
 
         // Extends the signature to the closest publication found in the
         // publications file
         // Assumes signature is not extended and at least one publication after
         // the signature obtained
-        KSISignature extendedSignature = ksi.extend(signature);
+        KSISignature extendedSignature = extender.extend(signature);
 
         // Double check if signature was extended
         if (extendedSignature.isExtended()) {
@@ -134,17 +141,19 @@ public class ExtendingSamples extends KsiSamples {
      */
     @Test
     public void extendToGivenPublicationDate() throws IOException, KSIException, ParseException {
-        KSI ksi = getKsi();
+        Reader reader = getReader();
+        Extender extender = getExtender();
+        PublicationsHandler publicationsHandler = getPublicationsHandler();
 
-        KSISignature signature = ksi.read(getFile("signme.txt.unextended-ksig"));
+        KSISignature signature = reader.read(getFile("signme.txt.unextended-ksig"));
         Date publicationDate = new SimpleDateFormat("yyyy-MM-dd").parse("2016-03-01");
 
-        PublicationRecord publicationRecord = ksi.getPublicationsFile().getPublicationRecord(publicationDate);
+        PublicationRecord publicationRecord = publicationsHandler.getPublicationsFile().getPublicationRecord(publicationDate);
 
         System.out.println("extendToGivenPublicationDate > trying to extend signature to publication > "
                 + publicationRecord.getPublicationTime());
 
-        KSISignature extendedSignature = ksi.extend(signature, publicationRecord);
+        KSISignature extendedSignature = extender.extend(signature, publicationRecord);
 
         if (extendedSignature.isExtended()) {
             System.out.println("extendToGivenPublicationDate > signature extended to publication > "
@@ -162,16 +171,19 @@ public class ExtendingSamples extends KsiSamples {
      */
     @Test
     public void extendToGivenPublicationCode() throws IOException, KSIException, ParseException {
-        KSI ksi = getKsi();
-        KSISignature signature = ksi.read(getFile("signme.txt.unextended-ksig"));
+        Reader reader = getReader();
+        PublicationsHandler publicationsHandler = getPublicationsHandler();
+        Extender extender = getExtender();
+
+        KSISignature signature = reader.read(getFile("signme.txt.unextended-ksig"));
 
         // Publication code for 15.03.2016
         Date publicationDate = new PublicationData(
                 "AAAAAA-CW45II-AAKWRK-F7FBNM-KB6FNV-DYYFW7-PJQN6F-JKZWBQ-3OQYZO-HCB7RA-YNYAGA-ODRL2V")
-                        .getPublicationTime();
+                .getPublicationTime();
 
-        PublicationRecord publicationRecord = ksi.getPublicationsFile().getPublicationRecord(publicationDate);
-        KSISignature extendedSignature = ksi.extend(signature, publicationRecord);
+        PublicationRecord publicationRecord = publicationsHandler.getPublicationsFile().getPublicationRecord(publicationDate);
+        KSISignature extendedSignature = extender.extend(signature, publicationRecord);
 
         if (extendedSignature.isExtended()) {
             System.out.println("extendToGivenPublicationCode > signature extended to publication > "

--- a/java-sdk/src/test/java/com/guardtime/ksi/samples/ExtendingSamples.java
+++ b/java-sdk/src/test/java/com/guardtime/ksi/samples/ExtendingSamples.java
@@ -15,15 +15,12 @@
 package com.guardtime.ksi.samples;
 
 import com.guardtime.ksi.Extender;
-import com.guardtime.ksi.KSI;
 import com.guardtime.ksi.PublicationsHandler;
 import com.guardtime.ksi.Reader;
 import com.guardtime.ksi.exceptions.KSIException;
 import com.guardtime.ksi.publication.PublicationData;
 import com.guardtime.ksi.publication.PublicationRecord;
 import com.guardtime.ksi.unisignature.KSISignature;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -35,16 +32,6 @@ import java.util.Date;
  * Samples related to extending KSI signatures.
  */
 public class ExtendingSamples extends KsiSamples {
-
-    @Before
-    public void setUp() throws KSIException {
-        setUpKsi();
-    }
-
-    @After
-    public void tearDown() {
-        tearDownKsi();
-    }
 
     /**
      * Check if signature has been extended to a publication or not.

--- a/java-sdk/src/test/java/com/guardtime/ksi/samples/KsiSamples.java
+++ b/java-sdk/src/test/java/com/guardtime/ksi/samples/KsiSamples.java
@@ -26,7 +26,8 @@ import com.guardtime.ksi.service.http.simple.SimpleHttpPublicationsFileClient;
 import com.guardtime.ksi.service.http.simple.SimpleHttpSigningClient;
 import com.guardtime.ksi.trust.X509CertificateSubjectRdnSelector;
 import com.guardtime.ksi.unisignature.Identity;
-import com.guardtime.ksi.unisignature.verifier.policies.ContextAwarePolicyAdapter;
+import org.junit.After;
+import org.junit.Before;
 
 import java.io.File;
 import java.io.IOException;
@@ -96,7 +97,8 @@ public abstract class KsiSamples {
      * points of the Aggregator and Extender services, the publications file location and the
      * credentials to access the services. Called from sub-classes before running the tests.
      */
-    protected void setUpKsi() throws KSIException {
+    @Before
+    public void setUpKsi() throws KSIException {
         // Get the Aggregator and Extender service end point URLs from JVM
         // properties
         aggregatorUrl = System.getProperty("aggregator.url");
@@ -116,8 +118,8 @@ public abstract class KsiSamples {
         certSelector = new X509CertificateSubjectRdnSelector("E=publications@guardtime.com");
 
         // Create reader for reading existing KSI signatures, each signature read is automatically verified
-        // using
-        reader = new SignatureReader(ContextAwarePolicyAdapter.createInternalPolicy());
+        // using internal verification policy. User can specify other policy when initializing the reader.
+        reader = new SignatureReader();
 
         // Create the signer for signing data
         ksiSigningClient = new SimpleHttpSigningClient(new CredentialsAwareHttpSettings(aggregatorUrl, credentials));
@@ -139,7 +141,8 @@ public abstract class KsiSamples {
     /**
      * Close resources after the tests have been finished. Called from sub-classes.
      */
-    protected void tearDownKsi() {
+    @After
+    public void tearDownKsi() {
         try {
             if (signer != null)
                 signer.close();

--- a/java-sdk/src/test/java/com/guardtime/ksi/samples/KsiSamples.java
+++ b/java-sdk/src/test/java/com/guardtime/ksi/samples/KsiSamples.java
@@ -129,7 +129,7 @@ public abstract class KsiSamples {
 
         // Create extender for extending KSI signatures
         ksiExtenderClient = new SimpleHttpExtenderClient(new CredentialsAwareHttpSettings(extenderUrl, credentials));
-        extender = new ExtenderBuilder().setExtendingService(new KSIExtendingClientServiceAdapter(ksiExtenderClient)).setKsiProtocolPublicationsFileClient(ksiPublicationsFileClient).setPublicationsFileCertificateConstraints(certSelector).build();
+        extender = new ExtenderBuilder().setExtendingService(new KSIExtendingClientServiceAdapter(ksiExtenderClient)).setPublicationsHandler(publicationsHandler).build();
 
         // Create verifier for verifying signatures
         verifier = new SignatureVerifier();

--- a/java-sdk/src/test/java/com/guardtime/ksi/samples/SignatureContentSamples.java
+++ b/java-sdk/src/test/java/com/guardtime/ksi/samples/SignatureContentSamples.java
@@ -14,28 +14,15 @@
  */
 package com.guardtime.ksi.samples;
 
-import com.guardtime.ksi.KSI;
 import com.guardtime.ksi.Reader;
 import com.guardtime.ksi.exceptions.KSIException;
 import com.guardtime.ksi.publication.PublicationData;
 import com.guardtime.ksi.unisignature.*;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
 
 public class SignatureContentSamples extends KsiSamples {
-
-    @Before
-    public void setUp() throws KSIException {
-        setUpKsi();
-    }
-
-    @After
-    public void tearDown() {
-        tearDownKsi();
-    }
 
     /**
      * Prints information found in the given signature's publication record.

--- a/java-sdk/src/test/java/com/guardtime/ksi/samples/SignatureContentSamples.java
+++ b/java-sdk/src/test/java/com/guardtime/ksi/samples/SignatureContentSamples.java
@@ -14,21 +14,16 @@
  */
 package com.guardtime.ksi.samples;
 
-import java.io.IOException;
-
+import com.guardtime.ksi.KSI;
+import com.guardtime.ksi.Reader;
+import com.guardtime.ksi.exceptions.KSIException;
+import com.guardtime.ksi.publication.PublicationData;
+import com.guardtime.ksi.unisignature.*;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import com.guardtime.ksi.KSI;
-import com.guardtime.ksi.exceptions.KSIException;
-import com.guardtime.ksi.publication.PublicationData;
-import com.guardtime.ksi.unisignature.AggregationHashChain;
-import com.guardtime.ksi.unisignature.CalendarAuthenticationRecord;
-import com.guardtime.ksi.unisignature.CalendarHashChain;
-import com.guardtime.ksi.unisignature.KSISignature;
-import com.guardtime.ksi.unisignature.SignatureData;
-import com.guardtime.ksi.unisignature.SignaturePublicationRecord;
+import java.io.IOException;
 
 public class SignatureContentSamples extends KsiSamples {
 
@@ -47,9 +42,9 @@ public class SignatureContentSamples extends KsiSamples {
      */
     @Test
     public void printPublicationRecord() throws IOException, KSIException {
-        KSI ksi = getKsi();
+        Reader reader = getReader();
 
-        KSISignature signature = ksi.read(getFile("signme.txt.extended-ksig"));
+        KSISignature signature = reader.read(getFile("signme.txt.extended-ksig"));
 
         SignaturePublicationRecord spr = signature.getPublicationRecord();
         if (spr != null)
@@ -63,8 +58,9 @@ public class SignatureContentSamples extends KsiSamples {
      */
     @Test
     public void printAggregationHashChain() throws IOException, KSIException {
-        KSI ksi = getKsi();
-        KSISignature signature = ksi.read(getFile("signme.txt.extended-ksig"));
+        Reader reader = getReader();
+
+        KSISignature signature = reader.read(getFile("signme.txt.extended-ksig"));
 
         for (AggregationHashChain ahc : signature.getAggregationHashChains()) {
             System.out.println("printAggregationHashChain > link count > " + ahc.getChainLinks().size());
@@ -76,25 +72,23 @@ public class SignatureContentSamples extends KsiSamples {
      */
     @Test
     public void printCalendarHashChain() throws IOException, KSIException {
-        KSI ksi = getKsi();
+        Reader reader = getReader();
 
-        KSISignature signature = ksi.read(getFile("signme.txt.extended-ksig"));
+        KSISignature signature = reader.read(getFile("signme.txt.extended-ksig"));
 
         CalendarHashChain chc = signature.getCalendarHashChain();
         System.out.println("printCalendarHashChain > publication time > " + chc.getPublicationTime());
-        System.out.println("printCalendarHashChain > registration time > " + chc.getRegistrationTime());
-
     }
 
     /**
-     * Prints the identity in the signature.
+     * Prints the client IDs of the identity metadata in the signature.
      */
     @Test
     public void printIdentity() throws IOException, KSIException {
-        KSI ksi = getKsi();
-        KSISignature signature = ksi.read(getFile("signme.txt.extended-ksig"));
+        Reader reader = getReader();
+        KSISignature signature = reader.read(getFile("signme.txt.extended-ksig"));
 
-        System.out.println("printIdentity > " + signature.getIdentity());
+        System.out.println(identityClientIdToString(signature.getAggregationHashChainIdentity()));
     }
 
     /**
@@ -102,9 +96,9 @@ public class SignatureContentSamples extends KsiSamples {
      */
     @Test
     public void printSigningTime() throws IOException, KSIException {
-        KSI ksi = getKsi();
+        Reader reader = getReader();
 
-        KSISignature signature = ksi.read(getFile("signme.txt.extended-ksig"));
+        KSISignature signature = reader.read(getFile("signme.txt.extended-ksig"));
 
         System.out.println("printSigningTime > " + signature.getAggregationTime());
     }
@@ -114,9 +108,9 @@ public class SignatureContentSamples extends KsiSamples {
      */
     @Test
     public void printCalendarAuthenticationRecord() throws IOException, KSIException {
-        KSI ksi = getKsi();
+        Reader reader = getReader();
 
-        KSISignature signature = ksi.read(getFile("signme.txt.unextended-ksig"));
+        KSISignature signature = reader.read(getFile("signme.txt.unextended-ksig"));
 
         CalendarAuthenticationRecord car = signature.getCalendarAuthenticationRecord();
         PublicationData publicationData = car.getPublicationData();

--- a/java-sdk/src/test/java/com/guardtime/ksi/samples/SigningSamples.java
+++ b/java-sdk/src/test/java/com/guardtime/ksi/samples/SigningSamples.java
@@ -14,32 +14,31 @@
  */
 package com.guardtime.ksi.samples;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
-import java.io.ByteArrayInputStream;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.nio.charset.Charset;
-import java.util.List;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Test;
-
 import com.guardtime.ksi.KSI;
+import com.guardtime.ksi.PublicationsHandler;
+import com.guardtime.ksi.Signer;
+import com.guardtime.ksi.Verifier;
+import com.guardtime.ksi.blocksigner.IdentityMetadata;
 import com.guardtime.ksi.blocksigner.KsiBlockSigner;
 import com.guardtime.ksi.exceptions.KSIException;
 import com.guardtime.ksi.hashing.DataHash;
 import com.guardtime.ksi.hashing.DataHasher;
 import com.guardtime.ksi.hashing.HashAlgorithm;
-import com.guardtime.ksi.unisignature.IdentityMetadata;
 import com.guardtime.ksi.unisignature.KSISignature;
+import com.guardtime.ksi.unisignature.verifier.policies.ContextAwarePolicy;
+import com.guardtime.ksi.unisignature.verifier.policies.ContextAwarePolicyAdapter;
 import com.guardtime.ksi.unisignature.verifier.policies.KeyBasedVerificationPolicy;
 import com.guardtime.ksi.unisignature.verifier.policies.Policy;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.naming.Context;
+import java.io.*;
+import java.nio.charset.Charset;
+import java.util.List;
+
+import static org.junit.Assert.*;
 
 public class SigningSamples extends KsiSamples {
 
@@ -58,7 +57,7 @@ public class SigningSamples extends KsiSamples {
      */
     @Test
     public void createAndSignSampleFile() throws IOException, KSIException {
-        KSI ksi = getKsi();
+        Signer signer = getSigner();
 
         // Let's create a file to be singed
         File fileToSign = new File("sample-file-for-signing.txt");
@@ -67,7 +66,7 @@ public class SigningSamples extends KsiSamples {
         writer.close();
 
         // Sign it, the hash of the document is computed implicitly by the sign method
-        KSISignature signature = ksi.sign(fileToSign);
+        KSISignature signature = signer.sign(fileToSign);
 
         // Persist signature to file
         FileOutputStream fileOutputStream = new FileOutputStream(new File("sample-file-for-signing.txt.ksig"));
@@ -80,7 +79,7 @@ public class SigningSamples extends KsiSamples {
      */
     @Test
     public void signSampleByteArray() throws IOException, KSIException {
-        KSI ksi = getKsi();
+        Signer signer = getSigner();
 
         // Whenever signing text data, make sure you control and know what the character set
         // (encoding) was otherwise you may have trouble in the verification later.
@@ -88,7 +87,7 @@ public class SigningSamples extends KsiSamples {
 
         // Sign it, the hash of the document is computed implicitly by the sign method
         @SuppressWarnings("unused")
-        KSISignature signature = ksi.sign(document);
+        KSISignature signature = signer.sign(document);
 
         // Persist signature to file
         // signature.writeTo(...);
@@ -100,7 +99,7 @@ public class SigningSamples extends KsiSamples {
      */
     @Test
     public void signHashDirectly() throws IOException, KSIException {
-        KSI ksi = getKsi();
+        Signer signer = getSigner();
 
         // Compute the hash first, use the input stream to provide the data to save memory for
         // hashing very large documents
@@ -111,7 +110,7 @@ public class SigningSamples extends KsiSamples {
 
         // Provide the signing method with the computed hash instead of document itself
         @SuppressWarnings("unused")
-        KSISignature signature = ksi.sign(dh.getHash());
+        KSISignature signature = signer.sign(dh.getHash());
 
         // Persist signature to file
         // signature.writeTo(...);
@@ -125,7 +124,7 @@ public class SigningSamples extends KsiSamples {
      */
     @Test
     public void signMultipleItemsWithLocalAggregation() throws KSIException {
-        KsiBlockSigner ksiBlockSigner = new KsiBlockSigner(getSimpleHttpClient());
+        KsiBlockSigner ksiBlockSigner = new KsiBlockSigner(getKsiSigningClient());
 
         int itemCount = 50;
 
@@ -148,7 +147,7 @@ public class SigningSamples extends KsiSamples {
         // to the block signer. One simple option to find the right signature is by
         // the input hash in the signature. It assumes that all the hashes added
         // were unique which is currently the case.
-        
+
         // In this example we find the hash for the item 15
         dh.reset();
         dh.addData(String.valueOf(15).getBytes());
@@ -156,9 +155,9 @@ public class SigningSamples extends KsiSamples {
 
         KSISignature s15 = null;
         for (KSISignature s : signatures) {
-        	if (s.getInputHash().equals(h)){
-        		s15 = s;
-        	}
+            if (s.getInputHash().equals(h)) {
+                s15 = s;
+            }
         }
 
         assertNotNull(s15);
@@ -171,11 +170,10 @@ public class SigningSamples extends KsiSamples {
      * are fixed and named after how KSI infrastructure uses them, its up to the use case what is
      * the content and interpretation of metadata to be embedded, KSI signature just ensures its
      * integrity.
-     * 
      */
     @Test
     public void linkUserIdToSignature() throws KSIException {
-        KsiBlockSigner ksiBlockSigner = new KsiBlockSigner(getSimpleHttpClient());
+        KsiBlockSigner ksiBlockSigner = new KsiBlockSigner(getKsiSigningClient());
         DataHasher dh = new DataHasher(HashAlgorithm.SHA2_256);
 
         // This is the data we are signing
@@ -194,7 +192,7 @@ public class SigningSamples extends KsiSamples {
         assertEquals(1, signatures.size());
 
         // Print the identity to show john.smith is there
-        System.out.println(signatures.get(0).getIdentity());
+        System.out.println(identityClientIdToString(signatures.get(0).getAggregationHashChainIdentity()));
 
         // Store the signature as needed
         // ...
@@ -210,12 +208,13 @@ public class SigningSamples extends KsiSamples {
      */
     @Test
     public void setHashLevel() throws KSIException {
-        KsiBlockSigner ksiBlockSigner = new KsiBlockSigner(getSimpleHttpClient());
-        KSI ksi = getKsi();
-        
+        KsiBlockSigner ksiBlockSigner = new KsiBlockSigner(getKsiSigningClient());
+        Verifier verifier = getVerifier();
+        PublicationsHandler publicationsHandler = getPublicationsHandler();
+
         // Assume that this is the root of the externally built Merkle tree and the level of the root is 5
-        DataHash rootHash = new DataHash(HashAlgorithm.SHA2_256, new byte[]{0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31});
-        
+        DataHash rootHash = new DataHash(HashAlgorithm.SHA2_256, new byte[]{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31});
+
         // Sign the root hash, but also specify the level (5) so that later
         // one can augment the received KSI signature with the hash chains of externally
         // built Merkle tree to get KSI signature down to the leaf of that external tree
@@ -223,16 +222,16 @@ public class SigningSamples extends KsiSamples {
         List<KSISignature> signatures = ksiBlockSigner.sign();
 
         // We should get only one signature as we only had one item that we signed
-        assertEquals(1, signatures.size());        
+        assertEquals(1, signatures.size());
         KSISignature sig = signatures.get(0);
-        
+
         // The received signature verifies fine without specifying the  
         // level of the hash because the level of the first hash is still 0
         // and the level correction of first link was set to 5 (so the next computed hash
         // is expected to be at level 5 + 1 instead of 0 + 1).
-        
-        Policy p = new KeyBasedVerificationPolicy();
-        assertTrue(ksi.verify(sig, p, rootHash).isOk());
+
+        ContextAwarePolicy contextAwarePolicy = ContextAwarePolicyAdapter.createKeyPolicy(getPublicationsHandler());
+        assertTrue(verifier.verify(sig, rootHash, 5L, contextAwarePolicy).isOk());
 
         // In order to augment this signature with an aggregation hash chain,
         // that was below the provided root, the level correction has to be removed (set to 0).

--- a/java-sdk/src/test/java/com/guardtime/ksi/samples/SigningSamples.java
+++ b/java-sdk/src/test/java/com/guardtime/ksi/samples/SigningSamples.java
@@ -14,7 +14,6 @@
  */
 package com.guardtime.ksi.samples;
 
-import com.guardtime.ksi.KSI;
 import com.guardtime.ksi.PublicationsHandler;
 import com.guardtime.ksi.Signer;
 import com.guardtime.ksi.Verifier;
@@ -27,13 +26,10 @@ import com.guardtime.ksi.hashing.HashAlgorithm;
 import com.guardtime.ksi.unisignature.KSISignature;
 import com.guardtime.ksi.unisignature.verifier.policies.ContextAwarePolicy;
 import com.guardtime.ksi.unisignature.verifier.policies.ContextAwarePolicyAdapter;
-import com.guardtime.ksi.unisignature.verifier.policies.KeyBasedVerificationPolicy;
-import com.guardtime.ksi.unisignature.verifier.policies.Policy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.naming.Context;
 import java.io.*;
 import java.nio.charset.Charset;
 import java.util.List;
@@ -41,16 +37,6 @@ import java.util.List;
 import static org.junit.Assert.*;
 
 public class SigningSamples extends KsiSamples {
-
-    @Before
-    public void setUp() throws KSIException {
-        setUpKsi();
-    }
-
-    @After
-    public void tearDown() {
-        tearDownKsi();
-    }
 
     /**
      * Creates a sample file, then signs it and stores the signature in a file.

--- a/java-sdk/src/test/java/com/guardtime/ksi/samples/VerificationSamples.java
+++ b/java-sdk/src/test/java/com/guardtime/ksi/samples/VerificationSamples.java
@@ -31,8 +31,6 @@ import com.guardtime.ksi.unisignature.KSISignature;
 import com.guardtime.ksi.unisignature.verifier.VerificationResult;
 import com.guardtime.ksi.unisignature.verifier.policies.ContextAwarePolicy;
 import com.guardtime.ksi.unisignature.verifier.policies.ContextAwarePolicyAdapter;
-import org.junit.After;
-import org.junit.Before;
 import org.junit.Test;
 
 import java.io.File;
@@ -40,16 +38,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 
 public class VerificationSamples extends KsiSamples {
-
-    @Before
-    public void setUp() throws KSIException {
-        setUpKsi();
-    }
-
-    @After
-    public void tearDown() {
-        tearDownKsi();
-    }
 
     /**
      * Verifies signature against a publication using the publications in the publication file. The


### PR DESCRIPTION
As the large KSI interface was refactored into several smaller interfaces (Signer, Extender, etc.) in version 4.10, the samples have been updated to use the new interfaces.